### PR TITLE
WIP: Discovery API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(LOADABLE_EXTENSION_NAME ${TARGET_NAME}_loadable_extension)
 project(${TARGET_NAME})
 include_directories(src/include duckdb/third_party/httplib duckdb/parquet/include)
 
-set(EXTENSION_SOURCES src/httpserver_extension.cpp)
+set(EXTENSION_SOURCES src/httpserver_extension.cpp src/discovery.cpp)
 
 if(MINGW)
   set(OPENSSL_USE_STATIC_LIBS TRUE)

--- a/docs/DISCOVERY.md
+++ b/docs/DISCOVERY.md
@@ -1,0 +1,71 @@
+## Discovery API
+
+- [x] POST `/subscribe/{secretHash}` - Register a peer
+- [x] GET `/discovery/{secretHash}` - Get list of active peers
+- [x] DELETE `/unsubscribe/{secretHash}/{peerId}` - Remove peer
+
+### Start Server
+```sql
+D SELECT httpserve_enable_discovery('true');
+D SELECT httpserve_start('0.0.0.0',9999, '');
+┌──────────────────────────────────────┐
+│ httpserve_start('0.0.0.0', 9999, '') │
+│               varchar                │
+├──────────────────────────────────────┤
+│ HTTP server started on 0.0.0.0:9999  │
+└──────────────────────────────────────┘
+```
+
+### Register a Peer under a secret hash
+#### CURL
+```bash
+curl -X POST "https://localhost:9999/subscribe/secretHash" \
+  -H "Content-Type: application/json" \
+  -d '{ "name": "service1", "endpoint": "http://192.168.1.100:8080", "ttl": 300 }
+```
+#### SQL
+```sql
+INSTALL http_client FROM community; LOAD http_client; LOAD json;
+WITH __input AS (
+    SELECT
+      http_post(
+          'http://localhost:9999/subscribe/secretHash',
+          headers => MAP {
+          },
+          params => MAP {
+            'name': 'quackpipe1',
+            'endpoint': 'https://1.1.1.1',
+          }
+      ) AS res
+  ) SELECT res->>'reason' as res, res->>'status' as status FROM __input;
+```
+
+### Check `peers` table
+```sql
+D SELECT name, endpoint, source_address as sourceAddress, peer_id as peerId, metadata, ttl, strftime(registered_at, '%Y-%m-%d %H:%M:%S') as registered_at FROM peers WHERE hash = 'secretHash';
+┌──────────┬───────────────────────────┬───────────────┬──────────────────────────────────┬──────────┬───────┬─────────────────────┐
+│   name   │         endpoint          │ sourceAddress │              peerId              │ metadata │  ttl  │    registered_at    │
+│ varchar  │          varchar          │    varchar    │             varchar              │ varchar  │ int64 │       varchar       │
+├──────────┼───────────────────────────┼───────────────┼──────────────────────────────────┼──────────┼───────┼─────────────────────┤
+│ service1 │ http://192.168.1.100:8080 │ xxx.xx.xx.xxx │ 0872c98634ce7e608e19aa1a1e6cf784 │ {}       │   300 │ 2024-11-14 19:44:23 │
+└──────────┴───────────────────────────┴───────────────┴──────────────────────────────────┴──────────┴───────┴─────────────────────┘
+```
+
+### Discover Peers
+#### CURL
+```bash
+curl "http://localhost:9999/discovery/secretHash"
+```
+#### SQL 
+```sql
+D SELECT * FROM read_ndjson_auto('http://localhost:9999/discovery/secretHash');
+┌──────────┬──────────────────────┬────────────────┬──────────────────────────────┬──────────┬─────────┬─────────────────────┐
+│   name   │       endpoint       │ source_address │           peer_id            │ metadata │   ttl   │    registered_at    │
+│ varchar  │       varchar        │    varchar     │             uuid             │ varchar  │ varchar │      timestamp      │
+├──────────┼──────────────────────┼────────────────┼──────────────────────────────┼──────────┼─────────┼─────────────────────┤
+│ service1 │ http://192.168.1.1…  │ 127.0.0.1      │ 0872c986-34ce-7e60-8e19-aa…  │          │ 3600    │ 2024-11-15 14:13:50 │
+└──────────┴──────────────────────┴────────────────┴──────────────────────────────┴──────────┴─────────┴─────────────────────┘
+D
+```
+
+⚠️ minor issue with peer_id being a UUID and clients hating it

--- a/src/discovery.cpp
+++ b/src/discovery.cpp
@@ -1,0 +1,102 @@
+#include "discovery.hpp"
+#include "mbedtls_wrapper.hpp"
+#include "duckdb/common/common.hpp"
+#include <chrono>
+#include <iostream>
+
+namespace duckdb {
+
+// Static member definition
+std::unique_ptr<PeerDiscovery> PeerDiscovery::instance = nullptr;
+
+// Constructor implementation
+PeerDiscovery::PeerDiscovery(DatabaseInstance& database) : db(database) {
+    initTables();
+}
+
+void PeerDiscovery::Initialize(DatabaseInstance& db) {
+    instance = std::unique_ptr<PeerDiscovery>(new PeerDiscovery(db));
+}
+
+void PeerDiscovery::initTables() {
+    Connection conn(db);
+    conn.Query("CREATE TABLE IF NOT EXISTS peers ("
+               "hash VARCHAR, peer_id VARCHAR, name VARCHAR, endpoint VARCHAR,"
+               "source_address VARCHAR, ttl BIGINT, metadata VARCHAR,"
+               "registered_at TIMESTAMP, PRIMARY KEY (hash, peer_id))");
+    
+    conn.Query("CREATE INDEX IF NOT EXISTS idx_peers_ttl ON peers(registered_at, ttl)");
+}
+
+std::string PeerDiscovery::generateDeterministicId(const std::string& name, const std::string& endpoint) {
+    std::string combined = name + ":" + endpoint;
+    hash_bytes hash;
+    duckdb_mbedtls::MbedTlsWrapper::ComputeSha256Hash(combined.c_str(), combined.length(), (char*)hash);
+    
+    std::string result;
+    for (int i = 0; i < 16; i++) {
+        char buf[3];
+        snprintf(buf, sizeof(buf), "%02x", hash[i]);
+        result += buf;
+    }
+    return result;
+}
+
+
+void PeerDiscovery::registerPeer(const std::string& hash, const PeerData& data) {
+   Connection conn(db);
+   std::string peerId = generateDeterministicId(data.name, data.endpoint);
+   
+   auto stmt = conn.Prepare(
+       "INSERT INTO peers (hash, peer_id, name, endpoint, source_address, ttl, metadata, registered_at) "
+       "VALUES ($1, $2, $3, $4, $5, $6, $7, CURRENT_TIMESTAMP)");
+   
+   vector<Value> params;
+   params.push_back(Value(hash));
+   params.push_back(Value(peerId));
+   params.push_back(Value(data.name));
+   params.push_back(Value(data.endpoint));
+   params.push_back(Value(data.sourceAddress));
+   params.push_back(Value::BIGINT(data.ttl));
+   params.push_back(Value(data.metadata));
+   
+   stmt->Execute(params);
+}
+
+std::unique_ptr<MaterializedQueryResult> PeerDiscovery::getPeers(const std::string& hash, bool ndjson) {
+   Connection conn(db);
+   auto stmt = conn.Prepare(
+       "SELECT name, endpoint, source_address as sourceAddress, "
+       "peer_id as peerId, metadata, "
+       "CAST(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - registered_at)) AS INTEGER) as age, "
+       "ttl FROM peers WHERE hash = $1 AND "
+       "EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - registered_at)) < ttl "
+       "ORDER BY age ASC");
+   
+   vector<Value> params;
+   params.push_back(Value(hash));
+   
+   auto result = stmt->Execute(params);
+   return unique_ptr<MaterializedQueryResult>((MaterializedQueryResult*)result.release());
+}
+
+void PeerDiscovery::removePeer(const std::string& hash, const std::string& peerId) {
+    Connection conn(db);
+    auto stmt = conn.Prepare("DELETE FROM peers WHERE hash = $1 AND peer_id = $2");
+    stmt->Execute(hash, peerId);
+}
+
+void PeerDiscovery::updateHeartbeat(const std::string& hash, const std::string& peerId) {
+    Connection conn(db);
+    auto stmt = conn.Prepare("UPDATE peers SET registered_at = CURRENT_TIMESTAMP "
+                           "WHERE hash = $1 AND peer_id = $2");
+    stmt->Execute(hash, peerId);
+}
+
+void PeerDiscovery::cleanupExpired() {
+    Connection conn(db);
+    conn.Query("DELETE FROM peers WHERE EXTRACT(EPOCH FROM "
+               "(CURRENT_TIMESTAMP - registered_at)) >= ttl");
+}
+
+} // namespace duckdb

--- a/src/discovery.cpp
+++ b/src/discovery.cpp
@@ -75,15 +75,10 @@ std::unique_ptr<MaterializedQueryResult> PeerDiscovery::getPeers(const std::stri
 
     // Execute the statement with the parameter
     vector<Value> params = {Value(hash)};
-    auto result = stmt->Execute(params);
+    auto raw_result = stmt->Execute(params);
+    auto result = raw_result->Cast<StreamQueryResult>().Materialize();
 
-    auto materialized_result = dynamic_cast<MaterializedQueryResult*>(result.get());
-    if (!materialized_result) {
-        throw std::runtime_error("Failed to retrieve materialized result.");
-    }
-
-    return std::unique_ptr<MaterializedQueryResult>(
-        static_cast<MaterializedQueryResult*>(result.release()));
+    return std::move(result);
 }
 
 void PeerDiscovery::removePeer(const std::string& hash, const std::string& peerId) {

--- a/src/discovery.cpp
+++ b/src/discovery.cpp
@@ -66,18 +66,17 @@ void PeerDiscovery::registerPeer(const std::string& hash, const PeerData& data) 
 std::unique_ptr<MaterializedQueryResult> PeerDiscovery::getPeers(const std::string& hash, bool ndjson) {
    Connection conn(db);
    auto stmt = conn.Prepare(
-       "SELECT name, endpoint, source_address as sourceAddress, "
-       "peer_id as peerId, metadata, "
-       "CAST(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - registered_at)) AS INTEGER) as age, "
-       "ttl FROM peers WHERE hash = $1 AND "
-       "EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - registered_at)) < ttl "
-       "ORDER BY age ASC");
+   "SELECT name, endpoint, source_address as sourceAddress, "
+   "peer_id as peerId, metadata, ttl, "
+   "strftime(registered_at, '%Y-%m-%d %H:%M:%S') as registered_at "
+   "FROM peers WHERE hash = $1");
    
    vector<Value> params;
    params.push_back(Value(hash));
-   
+   // FAIL
    auto result = stmt->Execute(params);
    return unique_ptr<MaterializedQueryResult>((MaterializedQueryResult*)result.release());
+
 }
 
 void PeerDiscovery::removePeer(const std::string& hash, const std::string& peerId) {

--- a/src/httpserver_extension.cpp
+++ b/src/httpserver_extension.cpp
@@ -66,7 +66,7 @@ static void SetEnvValue(DataChunk &args, ExpressionState &state, Vector &result,
                     throw std::invalid_argument(value_type + " cannot be empty.");
                 }
 #ifdef _WIN32
-   		 _putenv_s(name.c_str(), value.c_str());
+   		 _putenv_s(name.c_str(), value.GetString().c_str());
 #else
     		setenv(var_name.c_str(), value.GetString().c_str(), true);
 #endif

--- a/src/httpserver_extension.cpp
+++ b/src/httpserver_extension.cpp
@@ -65,7 +65,11 @@ static void SetEnvValue(DataChunk &args, ExpressionState &state, Vector &result,
                 if (value == "" || value.GetSize() == 0) {
                     throw std::invalid_argument(value_type + " cannot be empty.");
                 }
-		setenv(var_name.c_str(), value.GetString().c_str(), true);
+#ifdef _WIN32
+   		 _putenv_s(name.c_str(), value.c_str());
+#else
+    		setenv(var_name.c_str(), value.GetString().c_str(), true);
+#endif
 		auto new_value =  std::getenv("DUCKDB_HTTPSERVER_DISCOVERY");
                 return StringVector::AddString(result, value_type + " set ENV " + var_name +  " to: " + new_value ) ; //value.GetString()
             } catch (std::exception &e) {

--- a/src/httpserver_extension.cpp
+++ b/src/httpserver_extension.cpp
@@ -66,7 +66,7 @@ static void SetEnvValue(DataChunk &args, ExpressionState &state, Vector &result,
                     throw std::invalid_argument(value_type + " cannot be empty.");
                 }
 #ifdef _WIN32
-   		 _putenv_s(name.c_str(), value.GetString().c_str());
+   		 _putenv_s(name.GetString().c_str(), value.GetString().c_str());
 #else
     		setenv(var_name.c_str(), value.GetString().c_str(), true);
 #endif

--- a/src/httpserver_extension.cpp
+++ b/src/httpserver_extension.cpp
@@ -57,8 +57,8 @@ static void SetConfigValue(DataChunk &args, ExpressionState &state, Vector &resu
         });
 }
 
-static void SetEnvValue(DataChunk &args, ExpressionState &state, Vector &result, 
-                          const string &var_name, const string &value_type) {
+static void SetEnvValue(DataChunk &args, ExpressionState &state, Vector &result,
+                       const string &var_name, const string &value_type) {
     UnaryExecutor::Execute<string_t, string_t>(args.data[0], result, args.size(),
         [&](string_t value) {
             try {
@@ -66,12 +66,12 @@ static void SetEnvValue(DataChunk &args, ExpressionState &state, Vector &result,
                     throw std::invalid_argument(value_type + " cannot be empty.");
                 }
 #ifdef _WIN32
-   		 _putenv_s(name.GetString().c_str(), value.GetString().c_str());
+                _putenv_s(var_name.c_str(), value.GetString().c_str());
 #else
-    		setenv(var_name.c_str(), value.GetString().c_str(), true);
+                setenv(var_name.c_str(), value.GetString().c_str(), true);
 #endif
-		auto new_value =  std::getenv("DUCKDB_HTTPSERVER_DISCOVERY");
-                return StringVector::AddString(result, value_type + " set ENV " + var_name +  " to: " + new_value ) ; //value.GetString()
+                auto new_value = std::getenv("DUCKDB_HTTPSERVER_DISCOVERY");
+                return StringVector::AddString(result, value_type + " set ENV " + var_name + " to: " + new_value);
             } catch (std::exception &e) {
                 return StringVector::AddString(result, "Failed to set ENV " + var_name + " to " + value_type + ": " + e.what());
             }

--- a/src/httpserver_extension.cpp
+++ b/src/httpserver_extension.cpp
@@ -380,8 +380,6 @@ void HandleDiscoverySubscribe(const duckdb_httplib_openssl::Request& req, duckdb
         PeerDiscovery::Instance().registerPeer(hash, data);
         std::string peerId = PeerDiscovery::generateDeterministicId(data.name, data.endpoint);
         
-        std::cerr << "GOR PEERID for: " << peerId << std::endl;
-
         auto rdoc = yyjson_mut_doc_new(nullptr);
         auto rroot = yyjson_mut_obj(rdoc);
         yyjson_mut_doc_set_root(rdoc, rroot);
@@ -391,8 +389,6 @@ void HandleDiscoverySubscribe(const duckdb_httplib_openssl::Request& req, duckdb
         yyjson_mut_obj_add_int(rdoc, rroot, "ttl", data.ttl);
         
         char* json = yyjson_mut_write(rdoc, 0, nullptr);
-
-        std::cerr << "JSON OK for: " << peerId << std::endl;
 
         res.set_content(json, "application/json");
         free(json);

--- a/src/include/discovery.hpp
+++ b/src/include/discovery.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "duckdb.hpp"
+#include "duckdb/common/types.hpp"
+#include <memory>
+#include <string>
+
+namespace duckdb {
+
+using hash_bytes = uint8_t[32];
+
+struct PeerData {
+    std::string name;
+    std::string endpoint;
+    std::string sourceAddress;
+    int64_t ttl;
+    std::string metadata;
+};
+
+class PeerDiscovery {
+    static std::unique_ptr<PeerDiscovery> instance;
+    DatabaseInstance& db;
+
+    void initTables();
+    PeerDiscovery(DatabaseInstance& database);
+
+public:
+    static void Initialize(DatabaseInstance& db);
+    static PeerDiscovery& Instance() { return *instance; }
+    static std::string generateDeterministicId(const std::string& name, const std::string& endpoint);
+    
+    void registerPeer(const std::string& hash, const PeerData& data);
+    std::unique_ptr<MaterializedQueryResult> getPeers(const std::string& hash, bool ndjson = false);
+    void removePeer(const std::string& hash, const std::string& peerId);
+    void updateHeartbeat(const std::string& hash, const std::string& peerId);
+    void cleanupExpired();
+};
+
+} // namespace duckdb


### PR DESCRIPTION
## Discovery API

⚠️  This is just an experiment and will most likely end up in a different extension 

The optional discovery API offers an easy hook for servers to advertise and discover each other (flock)

### Endpoints
- [x] POST `/subscribe/{secretHash}` - Register a peer
- [x] GET `/discovery/{secretHash}` - Get list of active peers
- [x] DELETE `/unsubscribe/{secretHash}/{peerId}` - Remove peer

### Start Server w. `DUCKDB_HTTPSERVER_DISCOVERY=1`
```sql
D SELECT httpserve_start('0.0.0.0',9999, '');
┌──────────────────────────────────────┐
│ httpserve_start('0.0.0.0', 9999, '') │
│               varchar                │
├──────────────────────────────────────┤
│ HTTP server started on 0.0.0.0:9999  │
└──────────────────────────────────────┘
```

### Register a Peer under a secret hash
#### CURL
```bash
curl -X POST "https://localhost:9999/subscribe/secretHash" \
  -H "Content-Type: application/json" \
  -d '{ "name": "service1", "endpoint": "http://192.168.1.100:8080", "ttl": 300 }
```
#### SQL
```sql
INSTALL http_client FROM community; LOAD http_client; LOAD json;
WITH __input AS (
    SELECT
      http_post(
          'http://localhost:9999/subscribe/secretHash',
          headers => MAP {
          },
          params => MAP {
            'name': 'quackpipe1',
            'endpoint': 'https://1.1.1.1',
          }
      ) AS res
  ) SELECT res->>'reason' as res, res->>'status' as status FROM __input;
```

### Check `peers` table
```sql
D SELECT name, endpoint, source_address as sourceAddress, peer_id as peerId, metadata, ttl, strftime(registered_at, '%Y-%m-%d %H:%M:%S') as registered_at FROM peers WHERE hash = 'secretHash';
┌──────────┬───────────────────────────┬───────────────┬──────────────────────────────────┬──────────┬───────┬─────────────────────┐
│   name   │         endpoint          │ sourceAddress │              peerId              │ metadata │  ttl  │    registered_at    │
│ varchar  │          varchar          │    varchar    │             varchar              │ varchar  │ int64 │       varchar       │
├──────────┼───────────────────────────┼───────────────┼──────────────────────────────────┼──────────┼───────┼─────────────────────┤
│ service1 │ http://192.168.1.100:8080 │ xxx.xx.xx.xxx │ 0872c98634ce7e608e19aa1a1e6cf784 │ {}       │   300 │ 2024-11-14 19:44:23 │
└──────────┴───────────────────────────┴───────────────┴──────────────────────────────────┴──────────┴───────┴─────────────────────┘
```

### Discover Peers
#### CURL
```bash
curl "http://localhost:9999/discovery/secretHash"
```
#### SQL 
```sql
D SELECT * FROM read_ndjson_auto('http://localhost:9999/discovery/secretHash');
┌──────────┬──────────────────────┬────────────────┬──────────────────────────────┬──────────┬─────────┬─────────────────────┐
│   name   │       endpoint       │ source_address │           peer_id            │ metadata │   ttl   │    registered_at    │
│ varchar  │       varchar        │    varchar     │             uuid             │ varchar  │ varchar │      timestamp      │
├──────────┼──────────────────────┼────────────────┼──────────────────────────────┼──────────┼─────────┼─────────────────────┤
│ service1 │ http://192.168.1.1…  │ 127.0.0.1      │ 0872c986-34ce-7e60-8e19-aa…  │          │ 3600    │ 2024-11-15 14:13:50 │
└──────────┴──────────────────────┴────────────────┴──────────────────────────────┴──────────┴─────────┴─────────────────────┘
D
```

⚠️ minor issue with peer_id being a UUID and python hating it
