### PR TITLE
Request logger

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -4,6 +4,9 @@
 name: Main Extension Distribution Pipeline
 on:
   push:
+    paths-ignore:
+      - '**.md'
+      - '**..yml'
   pull_request:
   workflow_dispatch:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,7 @@ LOAD httpserver;
 Start the HTTP server providing the `host`, `port` and `auth` parameters.<br>
 > * If you want no authentication, just pass an empty string as parameter.<br>
 > * If you want the API run in foreground set `DUCKDB_HTTPSERVER_FOREGROUND=1`
+> * If you want logs set `DUCKDB_HTTPSERVER_DEBUG` or `DUCKDB_HTTPSERVER_SYSLOG`
 
 #### Basic Auth
 ```sql
@@ -90,7 +91,7 @@ D SELECT * FROM duck_flock('SELECT version()', ['http://localhost:9999']);
 │ "version"() │
 │   varchar   │
 ├─────────────┤
-│ v1.1.1      │
+│ v1.1.3      │
 └─────────────┘
 ```
 
@@ -122,7 +123,7 @@ curl -X POST -d "SELECT 'hello', version()" "http://localhost:9999/?default_form
   "data": [
     [
       "hello",
-      "v1.1.1"
+      "v1.1.3"
     ]
   ],
   "rows": 1,
@@ -153,7 +154,7 @@ D SELECT * FROM read_json_auto('http://localhost:9999/?q=SELECT version()');
 │ "version"() │
 │   varchar   │
 ├─────────────┤
-│ v1.1.1      │
+│ v1.1.3      │
 └─────────────┘
 ```
 

--- a/src/httpserver_extension.cpp
+++ b/src/httpserver_extension.cpp
@@ -9,16 +9,15 @@
 #include "duckdb/common/exception/http_exception.hpp"
 #include "duckdb/common/allocator.hpp"
 #include <chrono>
-
-#define CPPHTTPLIB_OPENSSL_SUPPORT
-#include "httplib.hpp"
-
-// Include yyjson for JSON handling
-#include "yyjson.hpp"
-
 #include <thread>
 #include <memory>
 #include <cstdlib>
+#include <syslog.h>
+
+#define CPPHTTPLIB_OPENSSL_SUPPORT
+#include "httplib.hpp"
+#include "yyjson.hpp"
+
 #include "play.h"
 
 using namespace duckdb_yyjson; // NOLINT

--- a/src/httpserver_extension.cpp
+++ b/src/httpserver_extension.cpp
@@ -384,6 +384,20 @@ void HttpServerStart(DatabaseInstance& db, string_t host, int32_t port, string_t
 
     string host_str = host.GetString();
 
+    const char* debug_env = std::getenv("DUCKDB_HTTPSERVER_DEBUG");
+    if (debug_env != nullptr && std::string(debug_env) == "1") {
+        global_state.server->set_logger([](const duckdb_httplib_openssl::Request& req, const duckdb_httplib_openssl::Response& res) {
+            auto now = std::chrono::system_clock::now();
+            auto now_time = std::chrono::system_clock::to_time_t(now);
+            fprintf(stdout, "[%s] %s %s - %d\n", 
+                std::ctime(&now_time), 
+                req.method.c_str(),
+                req.path.c_str(), 
+                res.status);
+            fflush(stdout);
+        });
+    }
+
     const char* run_in_same_thread_env = std::getenv("DUCKDB_HTTPSERVER_FOREGROUND");
     bool run_in_same_thread = (run_in_same_thread_env != nullptr && std::string(run_in_same_thread_env) == "1");
 


### PR DESCRIPTION
Adds two ENV variables for testing with debug and syslog output:

- `DUCKDB_HTTPSERVER_DEBUG`
- `DUCKDB_HTTPSERVER_SYSLOG`

Potential solution driver for #16 


```sql
# DUCKDB_HTTPSERVER_DEBUG=1 DUCKDB_HTTPSERVER_FOREGROUND=1 ./build/release/duckdb
v1.1.3 19864453f7
Enter ".help" for usage hints.
Connected to a transient in-memory database.
Use ".open FILENAME" to reopen on a persistent database.
D SELECT httpserve_start('0.0.0.0', 8123, '');
[2024-12-03 17:03:16] POST / - 200 - from xxxxxx:63795
[2024-12-03 17:03:21] POST / - 200 - from xxxxxx:63796
```

### syslog
```sql
# DUCKDB_HTTPSERVER_SYSLOG=1 DUCKDB_HTTPSERVER_FOREGROUND=1 ./build/release/duckdb
# tail /var/log/syslog
```
```bash
2024-12-03T17:48:28.886512+00:00 localhost duckdb-httpserver[380711]: POST / - 200 - from xxxxxx:64215
2024-12-03T17:48:29.083374+00:00 localhost duckdb-httpserver[380711]: POST / - 200 - from xxxxxx:64215
2024-12-03T17:48:32.788998+00:00 localhost duckdb-httpserver[380711]: POST / - 200 - from xxxxxx:64215
2024-12-03T17:48:33.277387+00:00 localhost duckdb-httpserver[380711]: POST / - 200 - from xxxxxx:64219
2024-12-03T17:48:33.427904+00:00 localhost duckdb-httpserver[380711]: POST / - 200 - from xxxxxx:64219
2024-12-03T17:48:33.616345+00:00 localhost duckdb-httpserver[380711]: POST / - 200 - from xxxxxx:64219
2024-12-03T17:48:33.800700+00:00 localhost duckdb-httpserver[380711]: POST / - 200 - from xxxxxx:64219
2024-12-03T17:48:34.000172+00:00 localhost duckdb-httpserver[380711]: POST / - 200 - from xxxxxx:64219
```