### PR TITLE
New Result Serialization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ add_custom_command(
 
 set(EXTENSION_SOURCES
     src/httpserver_extension.cpp
+    src/result_serializer.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/playground.hpp
 )
 

--- a/src/httpserver_extension.cpp
+++ b/src/httpserver_extension.cpp
@@ -95,21 +95,8 @@ static std::string ConvertResultToJSON(MaterializedQueryResult &result, ReqStats
     }
     yyjson_mut_obj_add_val(doc, root, "meta", meta_array);
 
-    // Add data
-    auto data_array = yyjson_mut_arr(doc);
-    for (idx_t row = 0; row < result.RowCount(); ++row) {
-        auto row_array = yyjson_mut_arr(doc);
-        for (idx_t col = 0; col < result.ColumnCount(); ++col) {
-            Value value = result.GetValue(col, row);
-            if (value.IsNull()) {
-                yyjson_mut_arr_append(row_array, yyjson_mut_null(doc));
-            } else {
-                std::string value_str = value.ToString();
-                yyjson_mut_arr_append(row_array, yyjson_mut_strncpy(doc, value_str.c_str(), value_str.length()));
-            }
-        }
-        yyjson_mut_arr_append(data_array, row_array);
-    }
+    ResultSerializer serializer;
+    auto data_array = serializer.Serialize(result);
     yyjson_mut_obj_add_val(doc, root, "data", data_array);
 
     // Add row count

--- a/src/httpserver_extension.cpp
+++ b/src/httpserver_extension.cpp
@@ -40,37 +40,11 @@ struct HttpServerState {
 
 static HttpServerState global_state;
 
-std::string GetColumnType(MaterializedQueryResult &result, idx_t column) {
+std::string GetColumnTypeName(MaterializedQueryResult &result, idx_t column) {
 	if (result.RowCount() == 0) {
 		return "String";
 	}
-	switch (result.types[column].id()) {
-		case LogicalTypeId::FLOAT:
-			return "Float";
-		case LogicalTypeId::DOUBLE:
-			return "Double";
-		case LogicalTypeId::INTEGER:
-			return "Int32";
-		case LogicalTypeId::BIGINT:
-			return "Int64";
-		case LogicalTypeId::UINTEGER:
-			return "UInt32";
-		case LogicalTypeId::UBIGINT:
-			return "UInt64";
-		case LogicalTypeId::VARCHAR:
-			return "String";
-		case LogicalTypeId::TIME:
-			return "DateTime";
-		case LogicalTypeId::DATE:
-			return "Date";
-		case LogicalTypeId::TIMESTAMP:
-			return "DateTime";
-		case LogicalTypeId::BOOLEAN:
-			return "Int8";
-		default:
-			return "String";
-	}
-	return "String";
+	return result.types[column].ToString();
 }
 
 struct ReqStats {
@@ -90,7 +64,7 @@ static std::string ConvertResultToJSON(MaterializedQueryResult &result, ReqStats
         auto column_obj = yyjson_mut_obj(doc);
         yyjson_mut_obj_add_str(doc, column_obj, "name", result.ColumnName(col).c_str());
         yyjson_mut_arr_append(meta_array, column_obj);
-        std::string tp(GetColumnType(result, col));
+        std::string tp(GetColumnTypeName(result, col));
         yyjson_mut_obj_add_strcpy(doc, column_obj, "type", tp.c_str());
     }
     yyjson_mut_obj_add_val(doc, root, "meta", meta_array);

--- a/src/httpserver_extension.cpp
+++ b/src/httpserver_extension.cpp
@@ -100,7 +100,7 @@ static std::string ConvertResultToJSON(MaterializedQueryResult &result, ReqStats
     yyjson_mut_obj_add_val(doc, root, "data", data_array);
 
     // Add row count
-    yyjson_mut_obj_add_int(doc, root, "rows", result.RowCount());
+    yyjson_mut_obj_add_uint(doc, root, "rows", result.RowCount());
     //"statistics":{"elapsed":0.00031403,"rows_read":1,"bytes_read":0}}
     auto stat_obj = yyjson_mut_obj_add_obj(doc, root, "statistics");
     yyjson_mut_obj_add_real(doc, stat_obj, "elapsed", req_stats.elapsed_sec);

--- a/src/include/httpserver_extension.hpp
+++ b/src/include/httpserver_extension.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "duckdb.hpp"
-#include "duckdb/common/file_system.hpp"
+#include "result_serializer.hpp"
 
 namespace duckdb {
 

--- a/src/include/result_serializer.hpp
+++ b/src/include/result_serializer.hpp
@@ -1,0 +1,106 @@
+#pragma once
+
+#include "duckdb/common/extra_type_info.hpp"
+#include "duckdb/common/types/uuid.hpp"
+#include "duckdb/main/query_result.hpp"
+#include "yyjson.hpp"
+
+#include <iostream>
+
+using namespace duckdb_yyjson;
+
+namespace duckdb {
+
+class SerializationResult {
+public:
+	virtual ~SerializationResult() = default;
+	virtual bool IsSuccess() = 0;
+	virtual string WithSuccessField() = 0;
+	virtual string Raw() = 0;
+
+	void Print() {
+		std::cerr << WithSuccessField() << std::endl;
+	}
+
+	template <class TARGET>
+	TARGET &Cast() {
+		DynamicCastCheck<TARGET>(this);
+		return reinterpret_cast<TARGET &>(*this);
+	}
+};
+
+class SerializationSuccess final : public SerializationResult {
+public:
+	explicit SerializationSuccess(string serialized) : serialized(std::move(serialized)) {
+	}
+
+	bool IsSuccess() override {
+		return true;
+	}
+
+	string Raw() override {
+		return serialized;
+	}
+
+	string WithSuccessField() override {
+		return R"({"success": true, "data": )" + serialized + "}";
+	}
+
+private:
+	string serialized;
+};
+
+class SerializationError final : public SerializationResult {
+public:
+	explicit SerializationError(string message) : message(std::move(message)) {
+	}
+
+	bool IsSuccess() override {
+		return false;
+	}
+
+	string Raw() override {
+		return message;
+	}
+
+	string WithSuccessField() override {
+		return R"({"success": false, "message": ")" + message + "\"}";
+	}
+
+private:
+	string message;
+};
+
+class ResultSerializer {
+public:
+	explicit ResultSerializer(const bool _set_invalid_values_to_null = false)
+	    : set_invalid_values_to_null(_set_invalid_values_to_null) {
+		doc = yyjson_mut_doc_new(nullptr);
+		root = yyjson_mut_arr(doc);
+		if (!root) {
+			throw InternalException("Could not create yyjson array");
+		}
+		yyjson_mut_doc_set_root(doc, root);
+	}
+	unique_ptr<SerializationResult> result;
+
+	~ResultSerializer() {
+		yyjson_mut_doc_free(doc);
+	}
+
+	void SerializeChunk(const DataChunk &chunk, vector<string> &names, vector<LogicalType> &types);
+
+	yyjson_mut_val* Serialize(QueryResult &query_result);
+
+private:
+
+
+	void SerializeValue(
+	    yyjson_mut_val *parent, const Value &value, optional_ptr<string> name, const LogicalType &type
+	);
+
+	yyjson_mut_doc *doc;
+	yyjson_mut_val *root;
+	bool set_invalid_values_to_null;
+};
+} // namespace duckdb

--- a/src/result_serializer.cpp
+++ b/src/result_serializer.cpp
@@ -1,0 +1,203 @@
+#include "result_serializer.hpp"
+
+
+// ReSharper disable once CppPassValueParameterByConstReference
+yyjson_mut_val* duckdb::ResultSerializer::Serialize(QueryResult &query_result) {
+	auto chunk = query_result.Fetch();
+	auto names = query_result.names;
+	auto types = query_result.types;
+	while (chunk) {
+		SerializeChunk(*chunk, names, types);
+		chunk = query_result.Fetch();
+	}
+
+	return root;
+}
+
+void duckdb::ResultSerializer::SerializeChunk(
+    const DataChunk &chunk, vector<string> &names, vector<LogicalType> &types
+) {
+	const auto column_count = chunk.ColumnCount();
+	const auto row_count = chunk.size();
+
+	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
+
+		// Which itself contains an object
+		// ReSharper disable once CppLocalVariableMayBeConst
+		auto obj = yyjson_mut_arr(doc);
+
+		for (idx_t col_idx = 0; col_idx < column_count; col_idx++) {
+
+			auto value = chunk.GetValue(col_idx, row_idx);
+			auto &type = types[col_idx];
+			SerializeValue(obj, value, nullptr, type);
+		}
+		if (!yyjson_mut_arr_append(root, obj)) {
+			throw InternalException("Could not add object to yyjson array");
+		}
+	}
+}
+
+void duckdb::ResultSerializer::SerializeValue( // NOLINT(*-no-recursion)
+    yyjson_mut_val *parent, const Value &value, optional_ptr<string> name, const LogicalType &type
+) {
+	yyjson_mut_val *val = nullptr;
+
+	if (value.IsNull()) {
+		goto null_handle;
+	}
+
+	switch (type.id()) {
+	case LogicalTypeId::SQLNULL:
+	null_handle:
+		val = yyjson_mut_null(doc);
+		break;
+	case LogicalTypeId::BOOLEAN:
+		val = yyjson_mut_bool(doc, value.GetValue<bool>());
+		break;
+	case LogicalTypeId::TINYINT:
+	case LogicalTypeId::SMALLINT:
+	case LogicalTypeId::INTEGER:
+	case LogicalTypeId::BIGINT:
+	case LogicalTypeId::INTEGER_LITERAL:
+		val = yyjson_mut_int(doc, value.GetValue<int64_t>());
+		break;
+	case LogicalTypeId::UTINYINT:
+	case LogicalTypeId::USMALLINT:
+	case LogicalTypeId::UINTEGER:
+	case LogicalTypeId::UBIGINT:
+		val = yyjson_mut_uint(doc, value.GetValue<uint64_t>());
+		break;
+	case LogicalTypeId::FLOAT:
+	case LogicalTypeId::DOUBLE:
+	case LogicalTypeId::DECIMAL: {
+		const auto real_val = value.GetValue<double>();
+		if (std::isnan(real_val) || std::isinf(real_val)) {
+			if (set_invalid_values_to_null) {
+				goto null_handle;
+			}
+			throw InvalidTypeException("NaN, Infinity, -Infinity are not supported");
+		}
+
+		val = yyjson_mut_real(doc, real_val);
+		break;
+	}
+		// Data + time
+	case LogicalTypeId::DATE:
+	case LogicalTypeId::TIME:
+	case LogicalTypeId::TIMESTAMP_SEC:
+	case LogicalTypeId::TIMESTAMP_MS:
+	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIMESTAMP_NS:
+	case LogicalTypeId::TIMESTAMP_TZ:
+	case LogicalTypeId::TIME_TZ:
+		// Enum
+	case LogicalTypeId::ENUM:
+		// Strings
+	case LogicalTypeId::CHAR:
+	case LogicalTypeId::VARCHAR:
+	case LogicalTypeId::STRING_LITERAL:
+		val = yyjson_mut_strcpy(doc, value.GetValue<string>().c_str());
+		break;
+	case LogicalTypeId::UUID: {
+		const auto uuid_int = value.GetValue<hugeint_t>();
+		const auto uuid = UUID::ToString(uuid_int);
+		val = yyjson_mut_strcpy(doc, uuid.c_str());
+		break;
+	}
+		// Weird special types that are jus serialized to string
+	case LogicalTypeId::INTERVAL:
+		// TODO perhaps base64 encode blob?
+	case LogicalTypeId::BLOB:
+	case LogicalTypeId::BIT:
+		val = yyjson_mut_strcpy(doc, value.ToString().c_str());
+		break;
+	case LogicalTypeId::UNION: {
+		auto &union_val = UnionValue::GetValue(value);
+		SerializeValue(parent, union_val, name, union_val.type());
+		return;
+	}
+	case LogicalTypeId::ARRAY:
+	case LogicalTypeId::LIST: {
+		const auto get_children = LogicalTypeId::LIST == type.id() ? ListValue::GetChildren : ArrayValue::GetChildren;
+		auto &children = get_children(value);
+		val = yyjson_mut_arr(doc);
+		for (auto &child : children) {
+			SerializeValue(val, child, nullptr, child.type());
+		}
+		break;
+	}
+	case LogicalTypeId::STRUCT: {
+		const auto &children = StructValue::GetChildren(value);
+		const auto &type_info = value.type().AuxInfo()->Cast<StructTypeInfo>();
+
+		auto all_keys_are_empty = true;
+		for (uint64_t idx = 0; idx < children.size(); ++idx) {
+			if (!type_info.child_types[idx].first.empty()) {
+				all_keys_are_empty = false;
+				break;
+			}
+		}
+
+		// Unnamed struct -> just create tuples
+		if (all_keys_are_empty) {
+			val = yyjson_mut_arr(doc);
+			for (auto &child : children) {
+				SerializeValue(val, child, nullptr, child.type());
+			}
+		} else {
+			val = yyjson_mut_obj(doc);
+			for (uint64_t idx = 0; idx < children.size(); ++idx) {
+				string struct_name = type_info.child_types[idx].first;
+				SerializeValue(val, children[idx], struct_name, type_info.child_types[idx].second);
+			}
+		}
+
+		break;
+	}
+		// Not implemented types
+	case LogicalTypeId::MAP: {
+		auto &children = ListValue::GetChildren(value);
+		val = yyjson_mut_obj(doc);
+		for (auto &item : children) {
+			auto &key_value = StructValue::GetChildren(item);
+			D_ASSERT(key_value.size() == 2);
+			auto key_str = key_value[0].GetValue<string>();
+			SerializeValue(val, key_value[1], key_str, key_value[1].type());
+		}
+		break;
+	}
+		// Unsupported types
+	case LogicalTypeId::TABLE:
+	case LogicalTypeId::UHUGEINT:
+	case LogicalTypeId::HUGEINT:
+	case LogicalTypeId::POINTER:
+	case LogicalTypeId::VALIDITY:
+	case LogicalTypeId::AGGREGATE_STATE:
+	case LogicalTypeId::LAMBDA:
+	case LogicalTypeId::USER:
+	case LogicalTypeId::ANY:
+	case LogicalTypeId::UNKNOWN:
+	case LogicalTypeId::INVALID:
+		if (set_invalid_values_to_null) {
+			goto null_handle;
+		}
+		throw InvalidTypeException("Type " + type.ToString() + " not supported");
+	}
+
+	D_ASSERT(val);
+	if (!name) {
+		if (!yyjson_mut_arr_append(parent, val)) {
+			throw InternalException("Could not add value to yyjson array");
+		}
+	} else {
+		yyjson_mut_val *key = yyjson_mut_strcpy(doc, name->c_str());
+		D_ASSERT(key);
+		if (!yyjson_mut_obj_add(parent, key, val)) {
+			throw InternalException("Could not add value to yyjson object");
+		}
+		if (!yyjson_mut_arr_add_val(parent, val)) {
+			throw InternalException("Could not add value to yyjson object");
+		}
+	}
+}


### PR DESCRIPTION
Hi Dear Quackscience Team, 

I was using the extension (I really love it!) and discovered that all the values are serialized as strings in the JsonCompact mode. This was sometimes a bit itchy for me, especially when I had list values or structs, etc., as I had to recursively parse the JSON to a class.  

This is why I propose changing to this new parser, which handles all the (nested) types in more detail. I tested it with `SELECT * FROM test_all_types();` and it did not crash (🎉). The new parser has large chunks of code from a parser that @NiclasHaderer once wrote, and I think he got inspired by the duckdb JSON extension. 

Also, I switched to an internal function to get the type name, as the current version often returned `string`. 

Let me know what you think and if you have some change requests. 

Best regards,
Paul
